### PR TITLE
improve performance by limiting the number of setTimeout operations in AsyncLoader

### DIFF
--- a/src/main/ts/AsyncLoader.ts
+++ b/src/main/ts/AsyncLoader.ts
@@ -46,19 +46,24 @@ class AsyncLoader {
 	public next() {
 		var nextItem: AsyncLoadingItem = this.items.shift();
 		if(nextItem !== undefined) {
-			this.showStatus(nextItem);
-		
-			window.setTimeout(() => {
-				//console.log("executing "+nextItem.label+ " ("+nextItem.index+"/"+nextItem.of+")");
-				this.execute(nextItem);
-			}, 0);
+            // avoid yielding control unnecessarily, but limit stack depth at the same time
+            if ((nextItem.index % 50) === 0) {
+                this.showStatus(nextItem);
+            
+                window.setTimeout(() => {
+                    //console.log("executing "+nextItem.label+ " ("+nextItem.index+"/"+nextItem.of+")");
+                    this.execute(nextItem);
+                }, 0);
+            } else {
+                this.execute(nextItem);
+            }
 		} else {
 			this.element.hidden = true;
 		}
 	}
 	
 	public showStatus(item: AsyncLoadingItem) {
-		this.element.innerHTML = item.label + " ("+(item.index+1)+"/"+item.of+")";
+		this.element.innerHTML = item.label + " (items: "+item.of+")";
 	}
 	
 	public execute(item: AsyncLoadingItem) {


### PR DESCRIPTION
I was a bit surprised to see the async loading indication count at about the same speed during pure calculations and actual DOM manipulation. It turns out that using setTimeout(..., 0) incurs a significant performance penalty.

Since the setTimeout seems to be only used for the status update, I think reducing its frequency is safe. It improved performance a lot - significantly below 1s vs. more than 3 seconds for the [git repo](https://github.com/git/git) on my machine.

My change now only yields control if a new kind of item is loaded (recognized by index == 0) or every 50 items (arbitrary limit to avoid stack overflows), whichever is sooner.