### PR TITLE
handling more complex merges (multiple anonymous)

### DIFF
--- a/src/main/ts/Gitline.ts
+++ b/src/main/ts/Gitline.ts
@@ -246,6 +246,7 @@ class Gitline {
 						if(headOnLane === undefined || headOnLane.branch != head && headOnLane.branch.lane === l && (tip.intersects(headOnLane) || tip.branch.category != headOnLane.branch.category)) {
 							canUseLane = false;
 						}
+						
 					}
 					
 					if(canUseLane) {


### PR DESCRIPTION
. removed code to reuse anonymous branches, lane cruncher will solve this.